### PR TITLE
fix: remove Python from CodeQL matrix (no Python code in repo)

### DIFF
--- a/.github/workflows/codeql1.yml
+++ b/.github/workflows/codeql1.yml
@@ -47,8 +47,6 @@ jobs:
           build-mode: none
         - language: javascript-typescript
           build-mode: none
-        - language: python
-          build-mode: none
         # CodeQL supports the following values keywords for 'language': 'actions', 'c-cpp', 'csharp', 'go', 'java-kotlin', 'javascript-typescript', 'python', 'ruby', 'rust', 'swift'
         # Use `c-cpp` to analyze code written in C, C++ or both
         # Use 'java-kotlin' to analyze code written in Java, Kotlin or both


### PR DESCRIPTION
## Summary

- Removes `python` from the language matrix in `codeql1.yml`
- This repo is a static GitHub Pages site with no Python source files; scanning for Python caused the CodeQL job to fail on every PR
- Retains `actions` and `javascript-typescript` scans which are relevant to the repo's content

## Test plan

- [ ] Confirm the `Analyze (python)` job no longer appears on this PR's checks
- [ ] Confirm `Analyze (actions)` and `Analyze (javascript-typescript)` still pass

---
_Generated by [Claude Code](https://claude.ai/code/session_01DhFNpvhf6rA3idxGDhwB5V)_