### PR TITLE
feat: automated monthly meetup site updater

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,8 +15,7 @@ dmvthrowers.club-ssl-bundle/
 # Local git mirror (no active purpose)
 repo-mirror/
 
-# Local dev/maintenance scripts (not part of the site)
-scripts/
+# scripts/ is tracked; add individual exclusions below for local-only files
 
 # GitHub Copilot dev tooling (not website content)
 agents/

--- a/scripts/update_meetup.py
+++ b/scripts/update_meetup.py
@@ -1,0 +1,319 @@
+#!/usr/bin/env python3
+"""
+DMV Throwers — Update 3rd Sunday meetup dates and clear past meetup events.
+
+Run this the Monday after each 3rd Sunday meetup to keep the site current:
+  1. Update "NEXT MEET" top bar in index.html and events.html
+  2. Remove past monthly meetup event cards from events.html
+  3. Remove past monthly meetup entries from the JSON-LD in events.html
+  4. Update sitemap.xml lastmod for index and events pages
+
+Usage:
+  python scripts/update_meetup.py
+  python scripts/update_meetup.py --repo /path/to/repo
+  python scripts/update_meetup.py --dry-run
+"""
+
+import argparse
+import json
+import re
+from datetime import date, timedelta
+from pathlib import Path
+import xml.etree.ElementTree as ET
+
+
+MONTH_NAMES = [
+    "January", "February", "March", "April", "May", "June",
+    "July", "August", "September", "October", "November", "December",
+]
+
+
+# ---------------------------------------------------------------------------
+# Date helpers
+# ---------------------------------------------------------------------------
+
+def third_sunday(year: int, month: int) -> date:
+    """Return the 3rd Sunday of the given year/month."""
+    d = date(year, month, 1)
+    days_to_first_sunday = (6 - d.weekday()) % 7
+    first_sunday = d + timedelta(days=days_to_first_sunday)
+    return first_sunday + timedelta(weeks=2)
+
+
+def upcoming_third_sundays(n: int = 12, today: date | None = None) -> list[date]:
+    """Return the next *n* third Sundays on or after *today*."""
+    if today is None:
+        today = date.today()
+    results: list[date] = []
+    y, m = today.year, today.month
+    while len(results) < n:
+        ts = third_sunday(y, m)
+        if ts >= today:
+            results.append(ts)
+        m += 1
+        if m > 12:
+            m, y = 1, y + 1
+    return results
+
+
+def fmt_upper(d: date) -> str:
+    """Return 'MONTH D, YYYY' with no leading zero, uppercased."""
+    return d.strftime("%B %d, %Y").replace(" 0", " ").upper()
+
+
+# ---------------------------------------------------------------------------
+# index.html + events.html — top-bar banner
+# ---------------------------------------------------------------------------
+
+_TOPBAR_RE = re.compile(
+    r"(NEXT MEET:\s*)"
+    r"((?:JANUARY|FEBRUARY|MARCH|APRIL|MAY|JUNE|JULY|AUGUST|SEPTEMBER|"
+    r"OCTOBER|NOVEMBER|DECEMBER)\s+\d{1,2},\s*\d{4})",
+    re.IGNORECASE,
+)
+
+
+def update_topbar(html_path: Path, next_date: date, dry_run: bool = False) -> bool:
+    """Replace the date in the 'NEXT MEET: …' top-bar span."""
+    text = html_path.read_text(encoding="utf-8")
+    new_str = fmt_upper(next_date)
+
+    if not _TOPBAR_RE.search(text):
+        print(f"  [!] NEXT MEET pattern not found in {html_path.name}")
+        return False
+
+    new_text = _TOPBAR_RE.sub(r"\g<1>" + new_str, text)
+    if new_text == text:
+        print(f"  [=] {html_path.name}: top bar already shows {new_str}")
+        return False
+
+    if not dry_run:
+        html_path.write_text(new_text, encoding="utf-8")
+    print(f"  [ok] {html_path.name}: top bar -> {new_str}")
+    return True
+
+
+# ---------------------------------------------------------------------------
+# events.html — remove past monthly meetup cards
+# ---------------------------------------------------------------------------
+
+# Matches exactly <div class="event-card"> (no extra classes).
+# Event-card divs sit at 4-space indent; inner divs are 6+ spaces, so
+# \n    </div> reliably marks only the outermost closing tag.
+_MEETUP_CARD_RE = re.compile(
+    r"\n    <div class=\"event-card\">\n(.*?)\n    </div>",
+    re.DOTALL,
+)
+
+
+def _parse_card_date(card_body: str, today: date) -> date | None:
+    """Extract the event date from a monthly meetup card body."""
+    m = re.search(
+        r'<div class="event-date">'
+        r"((?:January|February|March|April|May|June|July|August|"
+        r"September|October|November|December)\s+\d{1,2})</div>",
+        card_body,
+    )
+    if not m:
+        return None
+    parts = m.group(1).split()
+    try:
+        month_num = MONTH_NAMES.index(parts[0]) + 1
+        day = int(parts[1])
+        # Cards don't carry a year; assume current year.
+        # If that date would already be many months behind, it might be next year —
+        # but since we remove past cards, only "recently past" dates matter.
+        return date(today.year, month_num, day)
+    except (ValueError, IndexError):
+        return None
+
+
+def remove_past_meetup_cards(events_path: Path, today: date | None = None, dry_run: bool = False) -> bool:
+    """Remove monthly meetup cards whose dates precede *today*."""
+    if today is None:
+        today = date.today()
+
+    text = events_path.read_text(encoding="utf-8")
+    removed = 0
+
+    def replacer(m: re.Match) -> str:
+        nonlocal removed
+        body = m.group(1)
+        if "● MONTHLY MEETUP" not in body:
+            return m.group(0)  # keep (shouldn't happen with this exact class)
+        card_date = _parse_card_date(body, today)
+        if card_date is not None and card_date < today:
+            removed += 1
+            return ""
+        return m.group(0)
+
+    new_text = _MEETUP_CARD_RE.sub(replacer, text)
+
+    if removed == 0:
+        print(f"  [=] {events_path.name}: no past meetup cards to remove")
+        return False
+
+    if not dry_run:
+        events_path.write_text(new_text, encoding="utf-8")
+    print(f"  [ok] {events_path.name}: removed {removed} past meetup card(s)")
+    return True
+
+
+# ---------------------------------------------------------------------------
+# events.html — prune past monthly meetup entries from JSON-LD
+# ---------------------------------------------------------------------------
+
+_JSONLD_RE = re.compile(
+    r'(<script type="application/ld\+json">)\s*(.*?)\s*(</script>)',
+    re.DOTALL,
+)
+
+
+def remove_past_meetup_jsonld(events_path: Path, today: date | None = None, dry_run: bool = False) -> bool:
+    """
+    Parse the JSON-LD array in events.html and drop Event entries whose
+    name contains 'Monthly Meetup' and whose startDate is before *today*.
+    """
+    if today is None:
+        today = date.today()
+
+    text = events_path.read_text(encoding="utf-8")
+    m = _JSONLD_RE.search(text)
+    if not m:
+        print(f"  [!] {events_path.name}: JSON-LD block not found")
+        return False
+
+    try:
+        data = json.loads(m.group(2))
+    except json.JSONDecodeError as exc:
+        print(f"  [!] {events_path.name}: JSON-LD parse error - {exc}")
+        return False
+
+    if not isinstance(data, list):
+        print(f"  [!] {events_path.name}: JSON-LD is not an array, skipping")
+        return False
+
+    before = len(data)
+    filtered = []
+    for entry in data:
+        if entry.get("@type") == "Event" and "Monthly Meetup" in entry.get("name", ""):
+            start_iso = entry.get("startDate", "")[:10]  # YYYY-MM-DD
+            try:
+                event_date = date.fromisoformat(start_iso)
+            except ValueError:
+                filtered.append(entry)
+                continue
+            if event_date < today:
+                continue  # drop past entry
+        filtered.append(entry)
+
+    removed = before - len(filtered)
+    if removed == 0:
+        print(f"  [=] {events_path.name}: no past meetup JSON-LD entries to remove")
+        return False
+
+    new_json = json.dumps(filtered, indent=2, ensure_ascii=False)
+    new_text = (
+        text[: m.start()]
+        + m.group(1) + "\n"
+        + new_json + "\n"
+        + m.group(3)
+        + text[m.end() :]
+    )
+
+    if not dry_run:
+        events_path.write_text(new_text, encoding="utf-8")
+    print(f"  [ok] {events_path.name}: removed {removed} past meetup JSON-LD entry(ies)")
+    return True
+
+
+# ---------------------------------------------------------------------------
+# sitemap.xml — bump lastmod for index/events URLs
+# ---------------------------------------------------------------------------
+
+def update_sitemap(sitemap_path: Path, dry_run: bool = False) -> bool:
+    if not sitemap_path.exists():
+        return False
+    try:
+        tree = ET.parse(sitemap_path)
+        root = tree.getroot()
+        ns = {"sm": "http://www.sitemaps.org/schemas/sitemap/0.9"}
+        today_str = date.today().isoformat()
+        for url in root.findall("sm:url", ns):
+            loc = url.find("sm:loc", ns)
+            if loc is None:
+                continue
+            if any(tok in loc.text for tok in ("index", "events")):
+                lastmod = url.find("sm:lastmod", ns)
+                if lastmod is None:
+                    lastmod = ET.SubElement(
+                        url,
+                        "{http://www.sitemaps.org/schemas/sitemap/0.9}lastmod",
+                    )
+                lastmod.text = today_str
+        if not dry_run:
+            tree.write(str(sitemap_path), encoding="unicode", xml_declaration=False)
+        print(f"  [ok] sitemap.xml: lastmod updated to {today_str}")
+        return True
+    except Exception as exc:
+        print(f"  [!] sitemap.xml update skipped: {exc}")
+        return False
+
+
+# ---------------------------------------------------------------------------
+# Entry point
+# ---------------------------------------------------------------------------
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Update DMV Throwers meetup dates and clear past events."
+    )
+    parser.add_argument(
+        "--repo",
+        default=".",
+        help="Path to the repo root (default: current directory)",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Print planned changes without writing any files",
+    )
+    args = parser.parse_args()
+
+    repo = Path(args.repo).resolve()
+    today = date.today()
+    dates = upcoming_third_sundays(12, today)
+    next_date = dates[0]
+
+    print(f"Today       : {today.isoformat()}")
+    print(f"Next meetup : {next_date.strftime('%A, %B %d, %Y').replace(' 0', ' ')}")
+    if args.dry_run:
+        print("(dry-run - no files will be modified)\n")
+
+    index_html = repo / "index.html"
+    events_html = repo / "events.html"
+
+    print("\nindex.html:")
+    if index_html.exists():
+        update_topbar(index_html, next_date, args.dry_run)
+    else:
+        print("  [!] file not found")
+
+    print("\nevents.html:")
+    if events_html.exists():
+        update_topbar(events_html, next_date, args.dry_run)
+        remove_past_meetup_cards(events_html, today, args.dry_run)
+        remove_past_meetup_jsonld(events_html, today, args.dry_run)
+    else:
+        print("  [!] file not found")
+
+    print("\nsitemap.xml:")
+    update_sitemap(repo / "sitemap.xml", args.dry_run)
+
+    print("\nUpcoming meetups:")
+    for d in dates[:6]:
+        print(f"  {d.strftime('%A, %B %d, %Y').replace(' 0', ' ')}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/update_meetup.py
+++ b/scripts/update_meetup.py
@@ -120,12 +120,25 @@ def _parse_card_date(card_body: str, today: date) -> date | None:
     try:
         month_num = MONTH_NAMES.index(parts[0]) + 1
         day = int(parts[1])
-        # Cards don't carry a year; assume current year.
-        # If that date would already be many months behind, it might be next year —
-        # but since we remove past cards, only "recently past" dates matter.
-        return date(today.year, month_num, day)
     except (ValueError, IndexError):
         return None
+
+    # Cards omit the year, so we infer it. Assume today.year first; if that
+    # date is more than ~6 months in the past it's almost certainly a future
+    # card for next year (e.g. a January 2027 card encountered in November
+    # 2026 would otherwise be misread as January 2026 and deleted prematurely).
+    # A legitimately past card is at most ~1 month old (the just-finished
+    # meetup), so the 180-day threshold is a safe boundary.
+    try:
+        candidate = date(today.year, month_num, day)
+    except ValueError:
+        return None
+    if (today - candidate).days > 180:
+        try:
+            candidate = date(today.year + 1, month_num, day)
+        except ValueError:
+            return None
+    return candidate
 
 
 def remove_past_meetup_cards(events_path: Path, today: date | None = None, dry_run: bool = False) -> bool:

--- a/scripts/update_meetup.py
+++ b/scripts/update_meetup.py
@@ -19,7 +19,6 @@ import json
 import re
 from datetime import date, timedelta
 from pathlib import Path
-import xml.etree.ElementTree as ET
 
 
 MONTH_NAMES = [
@@ -123,17 +122,31 @@ def _parse_card_date(card_body: str, today: date) -> date | None:
     except (ValueError, IndexError):
         return None
 
-    # Cards omit the year, so we infer it. Assume today.year first; if that
-    # date is more than ~6 months in the past it's almost certainly a future
-    # card for next year (e.g. a January 2027 card encountered in November
-    # 2026 would otherwise be misread as January 2026 and deleted prematurely).
-    # A legitimately past card is at most ~1 month old (the just-finished
-    # meetup), so the 180-day threshold is a safe boundary.
+    # Cards omit the year; infer it from proximity to today.
+    # Two year-boundary cases need correction:
+    #
+    #   delta < -180  (>6 months in the past with today.year)
+    #     → probably a future card for next year.
+    #       e.g. a January 2027 card added in November 2026 reads as Jan 2026.
+    #       Threshold: 180 days comfortably clears the ~1-month "just-past" zone.
+    #
+    #   delta > 330  (>11 months in the future with today.year)
+    #     → probably a stale card from last year.
+    #       e.g. a December 2026 card still in the file in January 2027 reads
+    #       as December 2027. Threshold: 330 avoids false positives for
+    #       legitimately scheduled meetups 6–10 months out (e.g. a November
+    #       card encountered in May is only ~193 days away).
     try:
         candidate = date(today.year, month_num, day)
     except ValueError:
         return None
-    if (today - candidate).days > 180:
+    delta = (candidate - today).days
+    if delta > 330:
+        try:
+            candidate = date(today.year - 1, month_num, day)
+        except ValueError:
+            return None
+    elif delta < -180:
         try:
             candidate = date(today.year + 1, month_num, day)
         except ValueError:
@@ -244,29 +257,50 @@ def remove_past_meetup_jsonld(events_path: Path, today: date | None = None, dry_
 # sitemap.xml — bump lastmod for index/events URLs
 # ---------------------------------------------------------------------------
 
+# Pages whose lastmod should be refreshed after a meetup update.
+# Use exact URL strings to avoid false matches (e.g. "index" in a path).
+_SITEMAP_TARGETS = (
+    "https://dmvthrowers.club/",          # homepage — trailing slash, no "index"
+    "https://dmvthrowers.club/events.html",
+)
+
+# Matches a <loc>TARGET</loc> block followed (anywhere in the same <url>
+# element) by a <lastmod>YYYY-MM-DD</lastmod> to be replaced.
+# We do a text-level substitution to preserve the file's formatting,
+# comments, and XML declaration exactly — ET.write() would rewrite all of
+# that and add namespace prefixes on a first run.
+def _make_lastmod_re(url: str) -> re.Pattern[str]:
+    return re.compile(
+        r"(<loc>" + re.escape(url) + r"</loc>(?:(?!</url>).)*?<lastmod>)"
+        r"\d{4}-\d{2}-\d{2}"
+        r"(</lastmod>)",
+        re.DOTALL,
+    )
+
+
 def update_sitemap(sitemap_path: Path, dry_run: bool = False) -> bool:
+    """
+    Update <lastmod> for the homepage and events page in sitemap.xml.
+    Uses text-level substitution so the file's formatting and XML
+    declaration are preserved unchanged.
+    Only call this when index.html or events.html actually changed.
+    """
     if not sitemap_path.exists():
         return False
     try:
-        tree = ET.parse(sitemap_path)
-        root = tree.getroot()
-        ns = {"sm": "http://www.sitemaps.org/schemas/sitemap/0.9"}
+        text = sitemap_path.read_text(encoding="utf-8")
         today_str = date.today().isoformat()
-        for url in root.findall("sm:url", ns):
-            loc = url.find("sm:loc", ns)
-            if loc is None:
-                continue
-            if any(tok in loc.text for tok in ("index", "events")):
-                lastmod = url.find("sm:lastmod", ns)
-                if lastmod is None:
-                    lastmod = ET.SubElement(
-                        url,
-                        "{http://www.sitemaps.org/schemas/sitemap/0.9}lastmod",
-                    )
-                lastmod.text = today_str
+        new_text = text
+        for target_url in _SITEMAP_TARGETS:
+            new_text = _make_lastmod_re(target_url).sub(
+                r"\g<1>" + today_str + r"\2", new_text
+            )
+        if new_text == text:
+            print("  [=] sitemap.xml: lastmod already current")
+            return False
         if not dry_run:
-            tree.write(str(sitemap_path), encoding="unicode", xml_declaration=False)
-        print(f"  [ok] sitemap.xml: lastmod updated to {today_str}")
+            sitemap_path.write_text(new_text, encoding="utf-8")
+        print(f"  [ok] sitemap.xml: lastmod -> {today_str}")
         return True
     except Exception as exc:
         print(f"  [!] sitemap.xml update skipped: {exc}")
@@ -306,22 +340,30 @@ def main() -> None:
     index_html = repo / "index.html"
     events_html = repo / "events.html"
 
+    site_changed = False
+
     print("\nindex.html:")
     if index_html.exists():
-        update_topbar(index_html, next_date, args.dry_run)
+        site_changed |= update_topbar(index_html, next_date, args.dry_run)
     else:
         print("  [!] file not found")
 
     print("\nevents.html:")
     if events_html.exists():
-        update_topbar(events_html, next_date, args.dry_run)
-        remove_past_meetup_cards(events_html, today, args.dry_run)
-        remove_past_meetup_jsonld(events_html, today, args.dry_run)
+        site_changed |= update_topbar(events_html, next_date, args.dry_run)
+        site_changed |= remove_past_meetup_cards(events_html, today, args.dry_run)
+        site_changed |= remove_past_meetup_jsonld(events_html, today, args.dry_run)
     else:
         print("  [!] file not found")
 
+    # Only bump sitemap lastmod when index.html or events.html actually changed.
+    # Updating it unconditionally would cause a commit every Monday even when
+    # the meetup banner and cards were already current.
     print("\nsitemap.xml:")
-    update_sitemap(repo / "sitemap.xml", args.dry_run)
+    if site_changed:
+        update_sitemap(repo / "sitemap.xml", args.dry_run)
+    else:
+        print("  [=] skipped (no page content changed)")
 
     print("\nUpcoming meetups:")
     for d in dates[:6]:


### PR DESCRIPTION
## Summary

- Adds `scripts/update_meetup.py` — a Python script that updates the site after each 3rd Sunday meetup
- Adds `.github/workflows/update-meetup.yml` — runs every Monday morning (8 AM ET) to keep the site current
- Updates `.gitignore` to allow `scripts/` to be tracked (required for the CI workflow to call the script)

## What the script does

Each run (idempotent — safe to run any Monday):

1. **NEXT MEET banner** — updates the top-bar date in `index.html` and `events.html` to the next upcoming 3rd Sunday
2. **Past meetup cards** — removes `<div class="event-card">` blocks (plain monthly meetups only; special/holiday cards are untouched) whose date has passed
3. **JSON-LD cleanup** — parses the `application/ld+json` array in `events.html` and drops `Event` entries named "…Monthly Meetup" with a past `startDate`
4. **Sitemap** — bumps `lastmod` for index and events URLs

Supports `--dry-run` for local testing without writing files.

## Workflow trigger

```
schedule: cron "0 12 * * 1"   # every Monday 12:00 UTC = 8 AM ET
workflow_dispatch              # manual run from Actions tab anytime
```

The workflow only commits when `git diff` detects actual changes, so weeks without a just-passed meetup produce no commit noise. A successful push re-triggers the existing Pages deploy workflow automatically.

## Test plan

- [ ] Run `python scripts/update_meetup.py --repo . --dry-run` locally and verify output looks correct
- [ ] After merging, trigger the workflow manually from Actions → "Update Monthly Meetup Dates" → Run workflow
- [ ] Confirm the resulting commit updates `index.html` top bar and removes any stale JSON-LD entries
- [ ] Confirm the Pages deployment completes and the live site reflects the changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)