### PR TITLE
Add YoYo Pro Clicker app as a couch-judging resource

### DIFF
--- a/resources.html
+++ b/resources.html
@@ -69,7 +69,8 @@
         {"@type": "ListItem", "position": 8, "name": "Press Kit", "url": "https://dmvthrowers.club/resources.html"},
         {"@type": "ListItem", "position": 9, "name": "Scouts Yo-Yo Adventure", "url": "https://www.scouting.org/cub-scout-adventures/yo-yo/"},
         {"@type": "ListItem", "position": 10, "name": "YoYo Museum", "url": "https://www.yoyomuseum.com/"},
-        {"@type": "ListItem", "position": 11, "name": "YoYo Archive", "url": "https://yoyoarchive.org/"}
+        {"@type": "ListItem", "position": 11, "name": "YoYo Archive", "url": "https://yoyoarchive.org/"},
+        {"@type": "ListItem", "position": 12, "name": "YoYo Pro Clicker App", "url": "https://apps.apple.com/us/app/yoyo-pro-clicker/id6757318886"}
       ]
     }
   ]
@@ -270,6 +271,13 @@
         <div class="resource-title">YoYo Archive</div>
         <div class="resource-desc">Community-maintained database of yo-yo releases, competition results, and historical records. Also home to the YoYo Archive event calendar used across the community.</div>
         <a href="https://yoyoarchive.org/" class="resource-link" target="_blank" rel="noopener noreferrer">🔗 Visit YoYo Archive</a>
+      </div>
+
+      <div class="resource-card">
+        <div class="resource-icon">📱</div>
+        <div class="resource-title">YoYo Pro Clicker App</div>
+        <div class="resource-desc">Free iOS app for tracking freestyle deductions in real time — handy for couch judges helping score contests like VSYC-26.</div>
+        <a href="https://apps.apple.com/us/app/yoyo-pro-clicker/id6757318886" class="resource-link" target="_blank" rel="noopener noreferrer">📱 Get on the App Store</a>
       </div>
 
     </div>

--- a/vsyc26-rules.html
+++ b/vsyc26-rules.html
@@ -157,6 +157,7 @@
           <li>Judging follows NYYL scoring criteria — <a href="https://yoyocontest.com/freestyle-rules-for-nyyl-events/" target="_blank" rel="noopener noreferrer" class="rules-link">view full ruleset</a></li>
           <li>Judge decisions are final</li>
           <li>Respectful conduct required — unsportsmanlike behavior may result in disqualification</li>
+          <li>Couch judging welcome — use the <a href="https://apps.apple.com/us/app/yoyo-pro-clicker/id6757318886" target="_blank" rel="noopener noreferrer" class="rules-link">YoYo Pro Clicker app →</a> to track deductions along with our official judges</li>
           <li>All competitors and attendees are expected to follow the <a href="code-of-conduct.html" class="rules-link">DMV Throwers Code of Conduct →</a></li>
           <li>Venue rules apply to all competitors, spectators, and staff</li>
           <li>Organizers reserve the right to adjust format based on registration numbers</li>


### PR DESCRIPTION
## Summary
- Adds the [YoYo Pro Clicker](https://apps.apple.com/us/app/yoyo-pro-clicker/id6757318886) iOS app as a recommended tool for couch/audience judges in the VSYC-26 `JUDGING & CONDUCT` rule block.
- Adds a matching resource card (and JSON-LD `ItemList` entry) on `resources.html` so it's discoverable outside the contest rules page too.

## Test plan
- [x] Served the site locally (`python -m http.server`) and confirmed `resources.html` and `vsyc26-rules.html` return 200 and render the new content.
- [x] Verified the new link uses `target="_blank" rel="noopener noreferrer"` per convention.
- [x] Confirmed no CSP changes needed (plain outbound `<a>` navigation isn't governed by the page's CSP `meta` tag).


---
_Generated by [Claude Code](https://claude.ai/code/session_01TAW1fZ9vkLuws2K1dk2M6p)_