### PR TITLE
Credit Joseph as creator of the YoYo Pro Clicker app

### DIFF
--- a/resources.html
+++ b/resources.html
@@ -276,7 +276,7 @@
       <div class="resource-card">
         <div class="resource-icon">📱</div>
         <div class="resource-title">YoYo Pro Clicker App</div>
-        <div class="resource-desc">Free iOS app for tracking freestyle deductions in real time — handy for couch judges helping score contests like VSYC-26.</div>
+        <div class="resource-desc">Free iOS app for tracking freestyle deductions in real time — handy for couch judges helping score contests like VSYC-26. Built by fellow thrower Joseph (<a href="https://instagram.com/jo.vo.007" target="_blank" rel="noopener noreferrer" aria-label="Joseph's Instagram (opens in new tab)">@jo.vo.007</a>).</div>
         <a href="https://apps.apple.com/us/app/yoyo-pro-clicker/id6757318886" class="resource-link" target="_blank" rel="noopener noreferrer">📱 Get on the App Store</a>
       </div>
 

--- a/vsyc26-rules.html
+++ b/vsyc26-rules.html
@@ -157,7 +157,7 @@
           <li>Judging follows NYYL scoring criteria — <a href="https://yoyocontest.com/freestyle-rules-for-nyyl-events/" target="_blank" rel="noopener noreferrer" class="rules-link">view full ruleset</a></li>
           <li>Judge decisions are final</li>
           <li>Respectful conduct required — unsportsmanlike behavior may result in disqualification</li>
-          <li>Couch judging welcome — use the <a href="https://apps.apple.com/us/app/yoyo-pro-clicker/id6757318886" target="_blank" rel="noopener noreferrer" class="rules-link">YoYo Pro Clicker app →</a> to track deductions along with our official judges</li>
+          <li>Couch judging welcome — use the <a href="https://apps.apple.com/us/app/yoyo-pro-clicker/id6757318886" target="_blank" rel="noopener noreferrer" class="rules-link">YoYo Pro Clicker app →</a> (built by Joseph, <a href="https://instagram.com/jo.vo.007" target="_blank" rel="noopener noreferrer" class="rules-link">@jo.vo.007</a>) to track deductions along with our official judges</li>
           <li>All competitors and attendees are expected to follow the <a href="code-of-conduct.html" class="rules-link">DMV Throwers Code of Conduct →</a></li>
           <li>Venue rules apply to all competitors, spectators, and staff</li>
           <li>Organizers reserve the right to adjust format based on registration numbers</li>


### PR DESCRIPTION
## Summary
- Follow-up to #45 (merged). Credits Joseph as the creator of the YoYo Pro Clicker app, linking his Instagram (`@jo.vo.007`), on the `resources.html` card and the VSYC-26 `JUDGING & CONDUCT` rule item.

## Test plan
- [x] Served the site locally and confirmed `resources.html` and `vsyc26-rules.html` return 200.
- [x] Instagram link follows the site's existing convention (canonical `instagram.com/<handle>` URL, `target="_blank" rel="noopener noreferrer"`).


---
_Generated by [Claude Code](https://claude.ai/code/session_01TAW1fZ9vkLuws2K1dk2M6p)_